### PR TITLE
chore: use std::unordered_map over std::map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -503,3 +503,5 @@ FodyWeavers.xsd
 
 # Don't include POCs in repo
 poc/
+cmake-build-debug
+.DS_Store

--- a/libs/updateAddresses/src/converters/AddressesConverter.h
+++ b/libs/updateAddresses/src/converters/AddressesConverter.h
@@ -12,7 +12,7 @@
 
 namespace YAML {
   using model::Addresses;
-  using std::map;
+  using std::unordered_map;
   using std::string;
 
   template <>
@@ -25,8 +25,8 @@ namespace YAML {
     }
 
     static bool decode(const Node& node, Addresses& rhs) {
-      rhs.basePointers = node["basePointers"].as<map<string, model::BasePointer>>();
-      rhs.functions = node["functions"].as<map<string, stuff::types::Pointer>>();
+      rhs.basePointers = node["basePointers"].as<unordered_map<string, model::BasePointer>>();
+      rhs.functions = node["functions"].as<unordered_map<string, stuff::types::Pointer>>();
       return true;
     }
   };

--- a/libs/updateAddresses/src/converters/MetadataConverter.h
+++ b/libs/updateAddresses/src/converters/MetadataConverter.h
@@ -2,7 +2,7 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <map>
+#include <unordered_map>
 #include <string>
 
 #include "../model/AOB.h"
@@ -12,14 +12,14 @@
 namespace YAML {
   using model::AOB;
   using model::Metadata;
-  using std::map;
+  using std::unordered_map;
   using std::string;
 
   template <>
   struct convert<Metadata> {
     static bool decode(const Node& node, Metadata& rhs) {
-      rhs.basePointers = node["basePointers"].as<map<string, AOB>>();
-      rhs.functions = node["functions"].as<map<string, AOB>>();
+      rhs.basePointers = node["basePointers"].as<unordered_map<string, AOB>>();
+      rhs.functions = node["functions"].as<unordered_map<string, AOB>>();
       return true;
     }
   };

--- a/libs/updateAddresses/src/model/Addresses.h
+++ b/libs/updateAddresses/src/model/Addresses.h
@@ -2,17 +2,17 @@
 
 #include <types/address.h>
 
-#include <map>
+#include <unordered_map>
 #include <string>
 
 #include "BasePointer.h"
 
 namespace model {
-  using std::map;
+  using std::unordered_map;
   using std::string;
 
   struct Addresses {
-    map<string, model::BasePointer> basePointers;
-    map<string, stuff::types::Pointer> functions;
+    unordered_map<string, model::BasePointer> basePointers;
+    unordered_map<string, stuff::types::Pointer> functions;
   };
 }  // namespace model

--- a/libs/updateAddresses/src/model/Metadata.h
+++ b/libs/updateAddresses/src/model/Metadata.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <string>
 
 #include "AOB.h"
 
 namespace model {
-  using std::map;
+  using std::unordered_map;
   using std::string;
 
   struct Metadata {
-    map<string, AOB> basePointers;
-    map<string, AOB> functions;
+    unordered_map<string, AOB> basePointers;
+    unordered_map<string, AOB> functions;
   };
 }  // namespace model


### PR DESCRIPTION
- std::map is using a linked tree structure underneath, whereas
  unordered_map uses hashing

<!--
Please try to limit your pull request to one type, submit multiple pull requests if needed.
Copy/Keep the appropriate heading out of this comment:
# Bugfix
# Feature
# Code style update (formatting, renaming)
# Refactoring (no functional changes, no api changes)
# Build related changes
# Documentation content changes

# Other
> (please describe):
-->

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [ ] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

## Is this related to any currently open issues?
<!--
Mention the issue(s) this is related to. For more info, see:
https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically

For multiple issues, use a bulleted list. i.e:
 - Related to #23
 - Closes #23
 - Fixes #23
 - Resolves #23
 - Implements #23

Related to means only some progress was made. The others will close the issue once it's merged/
 -->

## What tests cover this change?

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
