### PR TITLE
Remove using namespace everywhere

### DIFF
--- a/libs/gamepad/src/dllmain.cpp
+++ b/libs/gamepad/src/dllmain.cpp
@@ -4,11 +4,9 @@
 
 #include "gamepad/GamepadDispatcher.h"
 
-using namespace gamepad;
+static gamepad::GamepadDispatcher instance;
 
-static GamepadDispatcher instance;
-
-IGamepadDispatcher& gamepad::GetDispatcher() {
+gamepad::IGamepadDispatcher& gamepad::GetDispatcher() {
   return instance;
 }
 

--- a/libs/stuff/src/hook/hook.cpp
+++ b/libs/stuff/src/hook/hook.cpp
@@ -2,22 +2,20 @@
 
 #include <MinHook.h>
 
-namespace stuff {
-  namespace hook {
-    void init() {
-      MH_Initialize();
-    }
+namespace hook {
+  void init() {
+    MH_Initialize();
+  }
 
-    void queue(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal) {
-      MH_CreateHook((LPVOID)pTarget, pDetour, ppOriginal);
-      MH_QueueEnableHook((LPVOID)pTarget);
-    }
-    void apply() {
-      MH_ApplyQueued();
-    }
+  void queue(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal) {
+    MH_CreateHook((LPVOID)pTarget, pDetour, ppOriginal);
+    MH_QueueEnableHook((LPVOID)pTarget);
+  }
+  void apply() {
+    MH_ApplyQueued();
+  }
 
-    void unhook() {
-      MH_DisableHook(MH_ALL_HOOKS);
-    }
-  }  // namespace hook
-}  // namespace stuff
+  void unhook() {
+    MH_DisableHook(MH_ALL_HOOKS);
+  }
+}  // namespace hook

--- a/libs/stuff/src/hook/hook.h
+++ b/libs/stuff/src/hook/hook.h
@@ -2,18 +2,16 @@
 
 #include <Windows.h>
 
-namespace stuff {
-  namespace hook {
-    void init();
+namespace hook {
+  void init();
 
-    void queue(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal);
+  void queue(LPVOID pTarget, LPVOID pDetour, LPVOID* ppOriginal);
 
-    template <typename T>
-    void queue(intptr_t pTarget, LPVOID pDetour, T** ppOriginal) {
-      queue((LPVOID)pTarget, pDetour, reinterpret_cast<LPVOID*>(ppOriginal));
-    }
+  template <typename T>
+  void queue(intptr_t pTarget, LPVOID pDetour, T** ppOriginal) {
+    queue((LPVOID)pTarget, pDetour, reinterpret_cast<LPVOID*>(ppOriginal));
+  }
 
-    void apply();
-    void unhook();
-  }  // namespace hook
-}  // namespace stuff
+  void apply();
+  void unhook();
+}  // namespace hook

--- a/libs/stuff/src/memory/memory.cpp
+++ b/libs/stuff/src/memory/memory.cpp
@@ -1,10 +1,7 @@
 #include "memory.h"
 
-#include <iostream>
-
 namespace stuff {
   namespace memory {
-    using namespace std;
     intptr_t followPointers(intptr_t base, const vector<intptr_t>& offsets, intptr_t exeBase) {
       auto addy = *(intptr_t*)(base + exeBase);
       int i = 0;

--- a/mods/mhw/common/src/MHW/chat.h
+++ b/mods/mhw/common/src/MHW/chat.h
@@ -8,8 +8,10 @@
 #include "chatMarkup.h"
 
 namespace MHW {
+  using ghidra::types::uint;
+  using ghidra::types::undefined;
+  using ghidra::types::undefined1;
   using stuff::types::Pointer;
-  using namespace ghidra::types;
   using SendSystemMessage = void (*)(undefined *, undefined *, float, uint, undefined1);
 
   class Chat {

--- a/mods/mhw/gamepad/src/dllmain.cpp
+++ b/mods/mhw/gamepad/src/dllmain.cpp
@@ -8,7 +8,6 @@
 #include <types/address.h>
 #include <yaml-cpp/yaml.h>
 
-using namespace stuff;
 using gamepad::Gamepad;
 using MHW::addressFile;
 using stuff::types::Pointer;

--- a/mods/mhw/hudToggler/src/dllmain.cpp
+++ b/mods/mhw/hudToggler/src/dllmain.cpp
@@ -7,7 +7,6 @@
 
 #include "plugin/HUDHookHelper.h"
 
-using namespace stuff;
 using plugin::HUDHookHelper;
 
 HUDHookHelper CaptainHook;

--- a/mods/mhw/loader/src/plugin/ConfigConverter.h
+++ b/mods/mhw/loader/src/plugin/ConfigConverter.h
@@ -9,12 +9,12 @@
 #include "config.h"
 
 namespace YAML {
-  using namespace loader;
-
-  std::map<std::string, LogLevel> logLevels = { { "DEBUG", DEBUG },
-                                                { "INFO", INFO },
-                                                { "WARNING", WARN },
-                                                { "ERROR", ERR } };
+  using loader::Config;
+  using loader::LogLevel;
+  std::map<std::string, LogLevel> logLevels = { { "DEBUG", LogLevel::DEBUG },
+                                                { "INFO", LogLevel::INFO },
+                                                { "WARNING", LogLevel::WARN },
+                                                { "ERROR", LogLevel::ERR } };
 
   template <>
   struct convert<Config> {

--- a/mods/mhw/loader/src/plugin/dll.cpp
+++ b/mods/mhw/loader/src/plugin/dll.cpp
@@ -21,7 +21,8 @@
 #include "../model/AddressesConverter.h"
 
 namespace dll {
-  using namespace loader;
+  using loader::LOG;
+  using loader::LogLevel;
   using MHW::addressFile;
   using MHW::Chat;
   using MHW::Color;
@@ -94,14 +95,14 @@ namespace dll {
 
       if (writeTime != std::get<FileTime>(dll)) {
         // TODO: consider comparing file hash
-        LOG(INFO) << "Reloading " << filePath;
+        LOG(LogLevel::INFO) << "Reloading " << filePath;
         MemoryFreeLibrary(std::get<HMEMORYMODULE>(dll));
         auto* memModule = LoadDll(filePath.string().c_str());
 
         auto pluginName = filePath.stem().string();
 
         if (!memModule) {
-          LOG(ERR) << "Failed to load " << filePath;
+          LOG(LogLevel::ERR) << "Failed to load " << filePath;
           chat.sendSystemMessage(
               std::format("{} {} reloading {}", failureIcon, failureText, pluginName),
               true);
@@ -123,10 +124,10 @@ namespace dll {
       if (entry.path().filename().extension().string() != ".dll") {
         continue;
       }
-      LOG(INFO) << "Loading plugin " << entry.path();
+      LOG(LogLevel::INFO) << "Loading plugin " << entry.path();
       auto* dll = LoadDll(entry.path().string().c_str());
       if (!dll) {
-        LOG(ERR) << "Failed to load " << entry.path();
+        LOG(LogLevel::ERR) << "Failed to load " << entry.path();
       } else {
         dlls.emplace_back(dll, entry.path(), entry.last_write_time());
       }

--- a/mods/mhw/lockOn2MapPin/src/dllmain.cpp
+++ b/mods/mhw/lockOn2MapPin/src/dllmain.cpp
@@ -3,7 +3,6 @@
 
 #include "plugin/LockOn2MapPin.h"
 
-using namespace stuff;
 using plugin::LockOn2MapPin;
 
 LockOn2MapPin CaptainHook;

--- a/mods/mhw/returnTimer/src/plugin/ReturnTimer.cpp
+++ b/mods/mhw/returnTimer/src/plugin/ReturnTimer.cpp
@@ -9,12 +9,14 @@
 #include "../model/AddressesConverter.h"
 
 namespace plugin {
-
+  using gamepad::Button;
+  using gamepad::Buttons;
+  using gamepad::Gamepad;
+  using gamepad::justPressed;
+  using gamepad::pressing;
   using MHW::addressFile;
   using MHW::readMem;
   using stuff::types::Offsets;
-
-  using namespace gamepad;
 
   ReturnTimer::ReturnTimer() {
     addresses = YAML::LoadFile(MHW::getFilePath(addressFile)).as<Addresses>();

--- a/mods/mhw/theFlash/src/plugin/Hermes.cpp
+++ b/mods/mhw/theFlash/src/plugin/Hermes.cpp
@@ -10,9 +10,12 @@
 #include "../model/AddressesConverter.h"
 
 namespace plugin {
+  using gamepad::Button;
+  using gamepad::Buttons;
+  using gamepad::Gamepad;
+  using gamepad::justPressed;
   using MHW::addressFile;
   using MHW::writeMem;
-  using namespace gamepad;
 
   Hermes::Hermes() {
     expBase = YAML::LoadFile(MHW::getFilePath(settings))["maxSpeedMultiplier"].as<int>();

--- a/mods/mhw/toggleSubtitles/src/dllmain.cpp
+++ b/mods/mhw/toggleSubtitles/src/dllmain.cpp
@@ -4,7 +4,6 @@
 
 #include "plugin/ToggleSubtitles.h"
 
-using namespace stuff;
 using gamepad::Gamepad;
 using gamepad::GamepadToken;
 using plugin::ToggleSubtitles;

--- a/mods/mhw/toggleSubtitles/src/plugin/ToggleSubtitles.cpp
+++ b/mods/mhw/toggleSubtitles/src/plugin/ToggleSubtitles.cpp
@@ -6,8 +6,10 @@
 #include "../model/AddressesConverter.h"
 
 namespace plugin {
+  using gamepad::Buttons;
+  using gamepad::Gamepad;
+  using gamepad::justPressed;
   using MHW::addressFile;
-  using namespace gamepad;
 
   ToggleSubtitles::ToggleSubtitles() {
     addresses = YAML::LoadFile(MHW::getFilePath(addressFile)).as<Addresses>();


### PR DESCRIPTION
# Refactoring (no functional changes, no api changes)

## Pull request checklist

<!-- Checkboxes can be checked like this: [x] -->

Please check if your PR fulfills the following requirements:
- [x] ~~Tests for the changes have been added (for bug fixes / features)~~
<!-- - [ ] Pre-commmit hook is enabled (`git config --get core.hooksPath` is _.githooks_) -->
- [x] ~~Docs have been reviewed and added / updated if needed (for bug fixes / features)~~

## What does this implement/fix? Explain your changes.

Removes `using namespace ...` everywhere. I used `using ...` where fully qualified names became unreadable.

## Is this related to any currently open issues?

Closes #25 

## What tests cover this change?

It compiles.

## Additional information

`clang-tidy` still fails, but now there are 0 warnings for `google-build-using-namespace`